### PR TITLE
Fix #16: now onTapping logo button you can redirect to college website

### DIFF
--- a/lib/src/core/common_widgets/college_logo.dart
+++ b/lib/src/core/common_widgets/college_logo.dart
@@ -1,20 +1,32 @@
 import 'package:flutter/material.dart';
 
 import '../constants/image_strings.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class CollegeLogo extends StatelessWidget {
   const CollegeLogo({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
+Widget build(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(8.0),
+    child: InkWell(
+      onTap: () async {
+        const url = 'https://jgec.ac.in/'; // Replace with the actual website URL
+        if (await canLaunch(url)) {
+          await launch(url);
+        } else {
+          // Handle the case where the URL cannot be launched
+          throw 'Could not launch $url';
+        }
+      },
       child: SizedBox.square(
-          dimension: 50,
-          child: Image.asset(collegeLogo,
-              color: Theme.of(context).brightness == Brightness.light
-                  ? Colors.black
-                  : Colors.white)),
-    );
-  }
+        dimension: 50,
+        child: Image.asset(collegeLogo,
+            color: Theme.of(context).brightness == Brightness.light
+                ? Colors.black
+                : Colors.white),
+      ),
+    ),
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   flutter_launcher_icons: 
   carousel_slider:
   lottie:
+  url_launcher: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Pull Request: Adding onTap functionality with InkWell and integrating url_launcher

## Description
This Pull Request introduces the onTap feature to the existing widget using `InkWell` and integrates the `url_launcher` package for opening a website when the widget is tapped.

## Changes Made
- Added `InkWell` to enable the onTap functionality.
- Integrated the `url_launcher` package for opening a website.
- Updated the `pubspec.yaml` file with the `url_launcher` dependency.


