### PR TITLE
Removed the green background from specified icons

### DIFF
--- a/lib/src/features/profile_screen/screens/widgets/account_list_tile.dart
+++ b/lib/src/features/profile_screen/screens/widgets/account_list_tile.dart
@@ -24,7 +24,7 @@ class AccountListTile extends StatelessWidget {
             title: Text(title, style: TextStyle(color: color)),
             trailing: (nextDisabled)
                 ? null
-                : IconButton.filled(
+                : IconButton(
                     color: Theme.of(context).colorScheme.onBackground,
                     onPressed: onPress,
                     icon: const Icon(Icons.arrow_circle_right_outlined))));


### PR DESCRIPTION
# Pull Request 🚀
Title: Fix icon color to always be white

## Summary

This PR Fixes #31 of white background of the specified arrow icons. 

## Solution
- Use normal `IconButton` instead of `IconButton.filled` to avoid filled background
##screenshot
![photo_2024-01-16_16-51-41](https://github.com/Abhigyan103/Clickboard/assets/106444983/438de4dc-2d8d-4394-81d3-7e28e8a5cad0)


